### PR TITLE
Update pa11y-dashboard.git reference to new official repo location.

### DIFF
--- a/pa11y-dashboard/Dockerfile
+++ b/pa11y-dashboard/Dockerfile
@@ -1,5 +1,5 @@
 # pa11y-dashboard Docker Container
-# https://github.com/springernature/pa11y-dashboard
+# https://github.com/pa11y/dashboard
 FROM node:5
 MAINTAINER Rob Loach <robloach@gmail.com>
 
@@ -22,7 +22,7 @@ ENV PA11Y_WEBSERVICE_CRON ${PA11Y_WEBSERVICE_CRON:-"0 30 0 * * *"}
 RUN npm install phantomjs-prebuilt@2 -g
 
 # Retrieve the dashboard
-RUN git clone https://github.com/pa11y/dashboard.git && cd pa11y-dashboard && npm i
+RUN git clone https://github.com/pa11y/dashboard.git && cd dashboard && npm i
 
 EXPOSE 4000
 EXPOSE 3000

--- a/pa11y-dashboard/Dockerfile
+++ b/pa11y-dashboard/Dockerfile
@@ -22,7 +22,7 @@ ENV PA11Y_WEBSERVICE_CRON ${PA11Y_WEBSERVICE_CRON:-"0 30 0 * * *"}
 RUN npm install phantomjs-prebuilt@2 -g
 
 # Retrieve the dashboard
-RUN git clone https://github.com/springernature/pa11y-dashboard.git && cd pa11y-dashboard && npm i
+RUN git clone https://github.com/pa11y/dashboard.git && cd pa11y-dashboard && npm i
 
 EXPOSE 4000
 EXPOSE 3000

--- a/pa11y-dashboard/docker-entrypoint.sh
+++ b/pa11y-dashboard/docker-entrypoint.sh
@@ -11,7 +11,7 @@ echo "{\n"\
 	"    \"port\": $PA11Y_WEBSERVICE_PORT,\n"\
 	"    \"cron\": \"$PA11Y_WEBSERVICE_CRON\"\n"\
 	"  }\n"\
-	"}" | tee /pa11y-dashboard/config/production.json
+	"}" | tee /dashboard/config/production.json
 
 # Start up the dashboard.
-cd /pa11y-dashboard && node .
+cd /dashboard && node .


### PR DESCRIPTION
**Overview**

`springernature/pa11y-dashboard.git` currently redirects to `pa11y/dashboard.git`. We might run into a future name collision if `springernature` ever adds their own repo named `pa11y-dashboard`. A better solution could be to point the current .git reference at the official `pa11y` repository. 

**Changes**

* Rename all `springernature` instances to `pa11y`.

* Update Dockerfile to support slightly changed folder naming convention. 