### PR TITLE
Update to use puppeteer instead of deprecated PhantomJS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,14 @@
 # pa11y-dashboard Docker Container
 # https://github.com/pa11y/dashboard
-FROM node:5
+FROM node:15.7.0-stretch-slim
+
 LABEL Rob Loach <robloach@gmail.com>
 
 # Dependencies
-RUN apt-get update -y && apt-get upgrade -y && apt-get install net-tools -y
+RUN apt-get update -y && apt-get upgrade -y && apt-get install -y gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget net-tools git
 
 # Environment variables
 ENV NODE_ENV ${NODE_ENV:-production}
-
-# Install PhantomJS
-RUN npm install phantomjs-prebuilt@2 -g
 
 # Retrieve the dashboard
 RUN git clone https://github.com/pa11y/dashboard.git && cd dashboard && npm i

--- a/production.json
+++ b/production.json
@@ -7,6 +7,10 @@
     "database": "mongodb://mongodb/pa11y-webservice",
     "host": "0.0.0.0",
     "port": 3000,
-    "cron": "0 30 0 * * *"
+    "cron": "0 30 0 * * *",
+    "chromeLaunchConfig": {
+       "args": ["--no-sandbox"]
+    }
+
   }
 }


### PR DESCRIPTION
I updated Dockerfile to remove Phantom.js dependencies, and modify production.js to add an option to run chromeheadless in a non sandbox mode.